### PR TITLE
update bans

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ newdata - The entire raw json object sent from the Dota client
     draft:pick
     draft:radiant_bonus_time
     draft:team#:home_team
-    draft:team#:ban#_class (0-5)
-    draft:team#:ban#_id (0-5)
+    draft:team#:ban#_class (0-6)
+    draft:team#:ban#_id (0-6)
     draft:team#:pick#_class (0-4)
     draft:team#:pick#_id (0-4)
 </details>


### PR DESCRIPTION
updated documentation to accomodate patch [7.34](https://dota2.fandom.com/wiki/Version_7.34) captain's mode rework from 6 bans to 7 bans


> Reworked Captains Mode Draft Order.
> Old: 2-3-2 Bans, 2-2-1 picks.
> First Pick Second Pick.
> Ban Ban Ban Ban.
> Pick Pick Pick Pick.
> Ban Ban Ban Ban Ban Ban.
> Pick Pick Pick Pick.
> Ban Ban Ban Ban.
> Pick Pick.
> New: 3-2-2 Bans (First Pick) 4-1-2 Bans (Second Pick) 1-3-1 picks (Both).
> First Pick Second Pick.
> Ban Ban Ban Ban Ban Ban Ban.
> Pick Pick.
> Ban Ban Ban.
> Pick Pick Pick Pick Pick Pick.
> Ban Ban Ban Ban.
> Pick Pick.
> Time per ban during the First Phase Bans decreased from 30s to 15s.